### PR TITLE
remove now moot overrides

### DIFF
--- a/index.json
+++ b/index.json
@@ -10,16 +10,8 @@
       2,
       "always"
     ],
-    "generator-star-spacing": [
-      2,
-      {
-        "before": true,
-        "after": true
-      }
-    ],
     "consistent-return": 1,
     "quote-props": 0,
-    "global-require": 1,
     "no-implicit-coercion": 1,
     "prefer-const": 0,
     "prefer-reflect": 0,


### PR DESCRIPTION
`generator-star-spacing` is the same as XO and `global-require` was removed in XO.