### PR TITLE
remove `consistent-return` rule override

### DIFF
--- a/index.json
+++ b/index.json
@@ -10,7 +10,6 @@
       2,
       "always"
     ],
-    "consistent-return": 1,
     "quote-props": 0,
     "no-implicit-coercion": 1,
     "prefer-const": 0,


### PR DESCRIPTION
I decided to remove it. It was more of an annoyance than useful: https://github.com/sindresorhus/eslint-config-xo/commit/970367e7b8bd023302f8d4c0725aa95bd37b1874