### PR TITLE
remove moot config

### DIFF
--- a/index.json
+++ b/index.json
@@ -6,14 +6,7 @@
       2,
       "always"
     ],
-    "babel/object-curly-spacing": [
-      2,
-      "always"
-    ],
-    "quote-props": 0,
     "no-implicit-coercion": 1,
-    "prefer-const": 0,
-    "prefer-reflect": 0,
-    "prefer-template": 0
+    "prefer-const": 0
   }
 }


### PR DESCRIPTION
Babel was removed from XO, so no longer needed. `quote-props` was changed to what you want. `prefer-template` was removed as it was annoying. `prefer-reflect` has never been enabled.